### PR TITLE
Review request team limitation

### DIFF
--- a/workflow-templates/google-chat-pr-review-requested.yml
+++ b/workflow-templates/google-chat-pr-review-requested.yml
@@ -6,6 +6,8 @@ on:
     
 jobs:
   build:
+    # Trigger job build only if a team is requested
+    if: github.event.requested_team.id
     runs-on: ubuntu-latest
 
     steps:
@@ -19,7 +21,7 @@ jobs:
                   "cardId": "unique-card-id",
                   "card": {
                     "header": {
-                      "title": "<font color=\"#2F81F7\">New PR</font>",
+                      "title": "<font color=\"#2F81F7\">New review requested</font>",
                       "subtitle": "${{ github.event.pull_request.title }}"
                     },
                     "sections": [
@@ -45,7 +47,7 @@ jobs:
                             "buttonList": {
                               "buttons": [
                                 {
-                                  "text": "OPEN PR",
+                                  "text": "Review",
                                   "onClick": {
                                     "openLink": {
                                       "url": "${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
- Rename some texts
- Trigger build only for team review request to avoid multiple "spam" notifications when users are automatically splited in the review